### PR TITLE
Change typo for "HTML Semantics" on documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -69,7 +69,7 @@
       </header>
       <br>
       <p>
-        Chota is <em>dead</em> simple to use. It doesn't require learning a lot of class names like other frameworks. It applies a few basic styles to the HTML following the <a href="https://www.w3schools.com/html/html5_semantic_elements.asp" target="_blank">HTML Semenatics</a>.
+        Chota is <em>dead</em> simple to use. It doesn't require learning a lot of class names like other frameworks. It applies a few basic styles to the HTML following the <a href="https://www.w3schools.com/html/html5_semantic_elements.asp" target="_blank">HTML Semantics</a>.
       </p>
       <p>Here is a <a href="https://cdn.rawgit.com/jenil/chota/v0.4.1/test/index.html">demo</a> of the basic HTML elements.</p>
       <br>


### PR DESCRIPTION
I've noticed a typo on the documentation in the following sentence:
`It applies a few basic styles to the HTML following the HTML *Semenatics.* `

This pull request should update the documentation