### PR TITLE
add .button.outline.error

### DIFF
--- a/src/_form.css
+++ b/src/_form.css
@@ -167,6 +167,11 @@ button[disabled]:hover {
   color: var(--color-darkGrey);
 }
 
+.button.outline.error {
+  box-shadow: inset 0 0 0 1px var(--color-error);
+  color: var(--color-error);
+}
+
 .button.clear {
   background-color: transparent;
   border-color: transparent;


### PR DESCRIPTION
The outline error button are very useful for a non-primary action that could trigger a dangerous action.

For example, this Github Pull Request form:

![example](http://i.imgur.com/rUF0y5Y.png)