### PR TITLE
Fix border-box resetting

### DIFF
--- a/src/_base.css
+++ b/src/_base.css
@@ -13,15 +13,16 @@
     "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-* {
-  box-sizing: border-box;
-}
-
 html {
+  box-sizing: border-box;
   font-size: 62.5%;
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
+}
+
+*, *:before, *:after {
+  box-sizing: inherit;
 }
 
 body {


### PR DESCRIPTION
Follow best practices around border-box resetting:

* Make it easier to change the box-sizing in plugins or other components
* Not all elements are content-box by default, so skip resetting them