### PR TITLE
Fix footer not being centered in docs (fixes #74)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -175,7 +175,7 @@
       </p>
     </section>
   </div>
-  <footer class="is-text-center">
+  <footer class="text-center">
     <p><a href="#top">🔝 Back to top</a> &bull; <a href="https://github.com/jenil/chota">🐛 Report an issue</a> &bull; <a href="https://paypal.me/jgog/10" target="_blank" onclick="ga('send', 'event', 'navigation', 'click', 'donate');">🎗 Donate</a></p>
     <p>Want icons for your project too? Checkout <a href="https://icongr.am" target="_blank">Icongr.am 🚀</a></p>
     <h5>Made by <a href="https://jgog.in" target="_blank">Jenil Gogari</a></h5>


### PR DESCRIPTION
The footer uses the `is-text-center` class, which doesn't exist and has no effect on the page. This class has been changed to `text-center` so that the footer is centered.