### PR TITLE
ci: add pull request quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - v1
+
+jobs:
+  quality-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}-${{ hashFiles('package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint CSS (stylelint)
+        run: yarn test
+
+      - name: Build (PostCSS + size gate)
+        run: yarn build

--- a/src/_util.css
+++ b/src/_util.css
@@ -213,3 +213,8 @@
     display: none !important;
   }
 }
+
+/* Intentional stylelint violation: vendor-prefixed property without autoprefixer */
+.test-break {
+  -webkit-appearance: none;
+}

--- a/src/_util.css
+++ b/src/_util.css
@@ -213,8 +213,3 @@
     display: none !important;
   }
 }
-
-/* Intentional stylelint violation: vendor-prefixed property without autoprefixer */
-.test-break {
-  -webkit-appearance: none;
-}


### PR DESCRIPTION
## Objective

Make pull requests to the long-lived v1 integration branch run the same reproducible quality gates that contributors run locally.

## Changes

- Added `ci.yml` workflow that runs on `pull_request` targeting `v1`
- Steps:
  1. **Install**: `yarn install --frozen-lockfile` (fail fast on missing deps)
  2. **Lint**: `yarn test` (stylelint on `src/*.css`)
  3. **Build**: `yarn build` (PostCSS + gzip size gate via `scripts/size-gate.js`)
- Cache key includes `yarn.lock` hash and `package.json` (which pins node version via `node-version-file`)
- No `continue-on-error`, no `allow-failure`, no baseline replacement
- Future hooks ready for #124 (VRT) and #130 (axe) to add steps

## Cache Key

```
${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}-${{ hashFiles('package.json') }}
```

This ensures cache invalidation when either the lockfile or package manager version changes.

## Acceptance

- [x] Workflow triggers on PRs targeting `v1`
- [x] Steps: install, lint, build (all visible as separate steps)
- [x] Cache keys include lockfile and runtime/toolchain version
- [x] No silent failure suppression
- [x] Compatible with future VRT and axe integration