### PR TITLE
docs(#141): document CSS-only interaction boundary for dropdowns and tabs

### DIFF
--- a/docs/_includes/navs.html
+++ b/docs/_includes/navs.html
@@ -94,4 +94,32 @@
   <a>Tab 3</a>
 </nav>
 {% endhighlight %}
+  <h5>CSS-only interaction boundary</h5>
+  <p>
+    <code>.tabs</code> styles <strong>visual navigation links</strong> — it sets
+    <code>display: flex</code> on the container and styles the <code>.tabs a</code> links
+    (padding, border-bottom, color). The <code>active</code> class (or
+    <code>aria-current="page"</code>) marks the current link visually. It is
+    <strong>not</strong> an ARIA Tabs widget: Chota does not add
+    <code>role="tablist"</code>, <code>role="tab"</code>, or <code>role="tabpanel"</code>, and
+    does <strong>not</strong> provide:
+  </p>
+  <ul>
+    <li>arrow-key switching between tabs</li>
+    <li>panel management (showing/hiding associated <code>role="tabpanel"</code> regions)</li>
+    <li>focus movement semantics (e.g. <kbd>Tab</kbd> moving into the active panel, <kbd>Arrow</kbd> moving between tabs)</li>
+  </ul>
+  <p>
+    The links inside <code>.tabs</code> are ordinary anchor navigation. Chota does provide a
+    visible keyboard-focus ring on those links via the <code>:focus-visible</code> rule: the
+    ring appears after keyboard <kbd>Tab</kbd> navigation and does not appear on a mouse
+    click. No tab-specific keyboard pattern is owned by Chota.
+  </p>
+  <p>
+    If you need a real tabbed interface — panels that switch with arrow keys, per the
+    WAI-ARIA Authoring Practices — you must add your own JavaScript and ARIA. Chota only
+    styles the visual nav; an application-owned widget is required for those interactions.
+    See the <a href="https://www.w3.org/WAI/ARIA/apg/patterns/tabs/">WAI-ARIA Authoring Practices for Tabs</a>
+    for the contract Chota does not own.
+  </p>
 </section>

--- a/docs/_includes/utilities.html
+++ b/docs/_includes/utilities.html
@@ -117,5 +117,41 @@
       </footer>
     </form>
   </details>
+  <h5>CSS-only interaction boundary</h5>
+  <p>
+    Chota is a CSS-only framework. The <code>&lt;details&gt;</code>/<code>&lt;summary&gt;</code>
+    element pair provides <strong>native disclosure behavior</strong> from the browser:
+    the <code>&lt;summary&gt;</code> is keyboard-focusable via <kbd>Tab</kbd>, activated by
+    <kbd>Enter</kbd> and <kbd>Space</kbd>, and toggles the open/closed state. This is
+    provided by the HTML specification and the browser, <em>not</em> by Chota.
+  </p>
+  <p>
+    The <code>.dropdown</code> class is purely visual styling — it sets
+    <code>position: relative</code> on the <code>&lt;details&gt;</code> and
+    <code>position: absolute</code> on its last child so the panel overlays surrounding
+    content. It does <strong>not</strong> turn <code>&lt;details&gt;</code> into a managed menu
+    widget. Chota does <strong>not</strong> provide:
+  </p>
+  <ul>
+    <li>roving focus among menu items (e.g. <kbd>Arrow</kbd> navigation between links)</li>
+    <li><code>role="menu"</code>, <code>role="menuitem"</code>, or <code>aria-haspopup</code> management</li>
+    <li>focus trapping or restoration when the panel closes</li>
+    <li><kbd>Escape</kbd>-to-close coordination or dismiss-on-blur</li>
+    <li>application-specific ARIA state (e.g. <code>aria-expanded</code> beyond what <code>&lt;details&gt;</code> already exposes natively)</li>
+  </ul>
+  <p>
+    Chota does provide a visible keyboard-focus ring on <code>&lt;summary&gt;</code> (and on
+    links, buttons, inputs, selects, textareas, and <code>[tabindex]</code> elements) via the
+    <code>:focus-visible</code> rule. The ring appears after keyboard navigation and does not
+    appear on a mouse click. Chota does <strong>not</strong> manage focus order, traps, or any
+    widget-specific keyboard pattern beyond what the browser provides natively.
+  </p>
+  <p>
+    If you need a real menu widget — for example a listbox or menu with arrow-key
+    navigation, selection, or dismiss-on-blur — you must add your own JavaScript and ARIA.
+    Chota only styles the visual container; an application-owned widget is required for
+    those interactions. See the <a href="https://www.w3.org/WAI/ARIA/apg/patterns/menubar/">WAI-ARIA Authoring Practices for Menu &amp; Menubar</a>
+    for the contract Chota does not own.
+  </p>
 </section>
 


### PR DESCRIPTION
## Card #141 — Document CSS-only interaction boundaries

**Type:** documentation-only (no production CSS, JS, ARIA, test, snapshot, or behavior changes).

### Problem
Chota is CSS-only. It styles `<details>/<summary>` (`.dropdown`) and `<a>` links inside `.tabs`, but does not provide JavaScript widget behavior. Users may mistake the visual styles for managed widgets (menu, ARIA Tabs). This PR documents the boundary in plain language.

### Changes
Two documentation includes only:

**`docs/_includes/utilities.html`** — "CSS-only interaction boundary" note appended to the Details/dropdown section (existing markup examples kept):
- Native `<details>/<summary>` provides disclosure behavior (`<summary>` Tab-focusable, Enter/Space toggle) — browser-native, not Chota-provided.
- `.dropdown` is purely visual (`position: relative` + absolute last child); it does not make `<details>` a managed menu widget.
- Chota does NOT provide: roving focus, `role="menu"`/`role="menuitem"`/`aria-haspopup`, focus trapping, Escape-to-close, dismiss-on-blur, or app ARIA state.
- `:focus-visible` shows a keyboard focus ring on `<summary>` (and other interactive elements); no focus order/trap/widget keyboard is owned.
- Real menu widgets require application JS + ARIA; links to WAI-ARIA APG (Menu & Menubar).

**`docs/_includes/navs.html`** — "CSS-only interaction boundary" note appended to the `.tabs` section (existing markup examples kept):
- `.tabs` styles visual navigation links; it is NOT an ARIA Tabs widget (no `role="tablist"`/`role="tab"`/`role="tabpanel"`, no arrow-key switching, no panel management, no focus movement semantics).
- `:focus-visible` shows a keyboard focus ring on tab links; mouse-click does not.
- Real tabbed interfaces require application JS + ARIA; links to WAI-ARIA APG (Tabs).

### Verified behavior
- Native `<details>` keyboard behavior (Chromium): after `Tab`, `document.activeElement` → `<summary>`; `Enter` toggles `open` true→false; `Space` toggles `open` true. Browser-native, not Chota-provided.
- `:focus-visible` rule lives at `src/_form.css` lines 84–92, covering `a, button, input, select, textarea, summary, [tabindex]`. Evidence test: `test/vrt/keyboard-focus.spec.js` (real `Tab` navigation, asserts `:focus-visible` matches + visible outline via `getComputedStyle`).
- Chota source is CSS-only: `grep -n "role=\|aria-\|haspopup\|tablist\|roving\|focus-trap" src/*.css` returns only `[aria-current="page"]` selectors (active-link styling hook), no widget roles.

### Scope exclusion
- `MIGRATION.md` line 25–26 ("No changes to utility classes or component markup") is consistent with the boundary — no edit needed.
- `README.md` makes no JS-widget claims — no edit needed.
- `docs/index.html` shows a pre-existing uncommitted modification in the worktree (dark-mode docs from another card); it is NOT staged in this PR and is out of scope for #141.

### Verification commands
| Command | Result |
|---|---|
| `yarn build` | exit 0; size gate 3372 bytes (baseline 3372, ceiling 4096) |
| `grep -n "role=\|aria-\|haspopup\|tablist\|roving\|focus-trap" src/*.css` | only `[aria-current="page"]` selectors; no widget roles |
| `grep -n "focus-visible\|outline" src/_form.css` | `:focus-visible` rule at lines 84–92 |
| `git diff --check v1...HEAD` | exit 0 (no whitespace errors) |
| `git diff --name-status v1...HEAD` | `M docs/_includes/navs.html`, `M docs/_includes/utilities.html` only |

### Done checklist
- [x] Dropdown and tabs documentation is technically accurate and internally consistent.
- [x] Docs distinguish native disclosure from managed menus and visual nav from ARIA Tabs.
- [x] Examples contain no unsupported accessibility claims (native `<details>` keyboard support is correctly attributed to the browser, not claimed absent).
- [x] No source behavior changes (source CSS, dist, tests, snapshots all untouched).

### Files changed
- `docs/_includes/navs.html` (+28)
- `docs/_includes/utilities.html` (+36)

Base: `v1` @ `78fbcf4`. Branch: `work/141-interaction-docs`. Commit: `3c6431d`.

Do not merge — coordinator handles merge + board updates.