### PR TITLE
docs(#140): document body.dark as a consumer convention

### DIFF
--- a/docs/examples/dark-mode.html
+++ b/docs/examples/dark-mode.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<!--
+  Card #140 — Dark-mode customization example.
+
+  This file demonstrates the documented `body.dark` CONVENTION:
+  - Chota ships NO `body.dark` rule and NO default dark palette.
+  - The overrides live in THIS file (the consumer), not in chota.css.
+  - The `.dark` class is added by THIS file's checkbox handler (a deterministic
+    switch), not by Chota and not by a `prefers-color-scheme` media query.
+  - Only the 14 documented Chota custom properties are overridden. See the
+    `:root` block in docs/index.html and test/vrt/api-manifest.json for the
+    full public API surface.
+
+  Open this file directly in a browser — no build, no Jekyll, no server.
+
+  NOTE on the side-by-side demo: the documented convention is `body.dark`
+  (overrides scoped to <body> with the .dark class). A single page only has
+  one <body>, so to show light and dark SIDE BY SIDE this demo additionally
+  mirrors the same overrides onto a `.demo-pane.dark` selector. The dark
+  preview pane is a `.demo-pane.dark` root, not <body>. The `body.dark` block
+  below is the documented contract; the `.demo-pane.dark` block is a
+  demo-only mirror so both states can coexist on one page. In your own site
+  you would use `body.dark` (or any selector you choose) — see the
+  "Customizing" section of docs/index.html.
+-->
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chota — dark-mode example (body.dark convention)</title>
+  <link rel="stylesheet" href="https://unpkg.com/chota" />
+  <style>
+    /*
+      Consumer-owned overrides — the documented `body.dark` convention.
+      This is the ONLY thing that makes "dark mode" dark. Chota defines no
+      body.dark rule; this block is yours. Override only the tokens you want
+      to change; the rest keep their light-theme defaults from chota.css.
+      The values below match the documented example in docs/index.html.
+    */
+    body.dark {
+      --bg-color: #000;
+      --bg-secondary-color: #131316;
+      --font-color: #f5f5f5;
+      --color-grey: #ccc;
+      --color-darkGrey: #777;
+    }
+
+    /*
+      Demo-only mirror so light and dark can coexist on one page. A single
+      page has only one <body>, so the side-by-side dark pane mirrors the
+      same overrides onto its own root. This block is NOT part of the
+      documented contract — it exists only for this demo. In your own site,
+      use `body.dark` (or any selector you choose).
+    */
+    .demo-pane.dark {
+      --bg-color: #000;
+      --bg-secondary-color: #131316;
+      --font-color: #f5f5f5;
+      --color-grey: #ccc;
+      --color-darkGrey: #777;
+      background-color: var(--bg-color);
+      color: var(--font-color);
+    }
+
+    /* Demo-only layout (not part of the dark-mode contract): */
+    .demo-pane { border: 1px solid var(--color-lightGrey); padding: 1.5rem; border-radius: .4rem; }
+    .demo-label { font-size: 1.2rem; color: var(--color-darkGrey); margin-bottom: 1rem; }
+  </style>
+</head>
+<body id="top">
+  <div class="container">
+    <header class="row is-mobile">
+      <div class="col">
+        <h1>Dark mode — <code>body.dark</code> convention</h1>
+        <p>
+          Chota ships <strong>no built-in dark theme</strong>. <code>body.dark</code> is a
+          <strong>consumer convention</strong>: a selector <em>you</em> own, where you
+          override Chota's custom properties. The class itself does nothing without the
+          overrides (there is no default dark palette to fall back to), and Chota does not
+          add the class for you.
+        </p>
+        <p>
+          This page renders light and dark states <strong>side by side from a deterministic
+          switch</strong> (the checkbox below) so you can see both without relying on the OS
+          preference. The two panes use identical markup; only the <code>.dark</code> class on
+          the dark pane's root differs.
+        </p>
+        <p>
+          <label class="is-mobile">
+            <input id="dark-toggle" type="checkbox" checked />
+            Apply the dark overrides to the dark preview pane
+          </label>
+        </p>
+      </div>
+    </header>
+
+    <hr />
+
+    <!--
+      Two panes with identical markup. The LIGHT pane never gets .dark.
+      The DARK pane is toggled by the checkbox below. Because a page has only
+      one <body>, the side-by-side dark pane uses a demo-only mirror selector
+      (.demo-pane.dark) that carries the same overrides as the documented
+      body.dark block above. See the file's top comment for the rationale.
+    -->
+    <div class="row">
+      <div class="col-6">
+        <div class="demo-pane" id="light-pane">
+          <p class="demo-label">Light (default — no <code>.dark</code> class)</p>
+          <div class="card">
+            <header><h4>Card</h4></header>
+            <p>This card consumes <code>--bg-color</code> for its background.</p>
+            <footer class="is-right">
+              <a class="button primary">Submit</a>
+              <a class="button">Cancel</a>
+            </footer>
+          </div>
+          <p>
+            <span class="tag">tag</span>
+            <span class="tag is-small">small tag</span>
+            — tags consume <code>--color-grey</code>.
+          </p>
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="demo-pane" id="dark-pane">
+          <p class="demo-label">Dark (<code>.dark</code> class + consumer overrides)</p>
+          <div class="card">
+            <header><h4>Card</h4></header>
+            <p>This card consumes <code>--bg-color</code> for its background.</p>
+            <footer class="is-right">
+              <a class="button primary">Submit</a>
+              <a class="button">Cancel</a>
+            </footer>
+          </div>
+          <p>
+            <span class="tag">tag</span>
+            <span class="tag is-small">small tag</span>
+            — tags consume <code>--color-grey</code>.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <hr />
+    <h3>What this example proves</h3>
+    <ul>
+      <li>
+        <strong>Chota defines no <code>body.dark</code> rule.</strong> The dark palette comes
+        entirely from the <code>&lt;style&gt;</code> block in this file (the consumer), not
+        from <code>chota.css</code>.
+      </li>
+      <li>
+        <strong>The class does nothing without the overrides.</strong> Uncheck the toggle:
+        the dark pane loses the <code>.dark</code> class and falls back to the light theme.
+        The overrides (not the class) are what make it dark.
+      </li>
+      <li>
+        <strong>Only documented custom properties are used</strong>:
+        <code>--bg-color</code>, <code>--bg-secondary-color</code>, <code>--font-color</code>,
+        <code>--color-grey</code>, <code>--color-darkGrey</code>. These are part of the
+        public API surface (see <code>docs/index.html</code> and
+        <code>test/vrt/api-manifest.json</code>).
+      </li>
+      <li>
+        <strong>The "when to apply" decision is yours.</strong> Here a deterministic checkbox
+        toggle is used for demo purposes. In a real site you might use a
+        <code>prefers-color-scheme</code> media query, a JS toggle, or a stored user
+        preference — Chota does not add the class for you.
+      </li>
+    </ul>
+    <p>
+      <a href="../index.html#dark-mode">Back to the Customizing section</a>
+    </p>
+  </div>
+
+  <script>
+    // Deterministic demo switch (NOT shipped by Chota). Toggles the .dark class
+    // on the dark preview pane's root so you can see both states without the OS
+    // preference. In a real consumer, this is YOUR decision to make.
+    (function () {
+      var toggle = document.getElementById('dark-toggle');
+      var darkPane = document.getElementById('dark-pane');
+      function apply() {
+        if (toggle.checked) {
+          darkPane.classList.add('dark');
+        } else {
+          darkPane.classList.remove('dark');
+        }
+      }
+      toggle.addEventListener('change', apply);
+      apply();
+    })();
+  </script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,9 +117,54 @@
 /* Other styles..... */
 {% endhighlight %}
 <br>
-<p>Addtionally, you can add dark mode to your site, to support devices that prefer dark mode.</p>
+<h4 id="dark-mode">Dark mode</h4>
+<p>
+  Chota ships <strong>no built-in dark theme</strong>. The <code>body.dark</code>
+  selector you may have seen in examples is <strong>a consumer convention</strong>,
+  not a Chota style block: Chota defines <em>no</em> <code>body.dark</code> rule.
+  It is a hook <em>you</em> own, where you override Chota's custom properties
+  with the values you want for a dark palette.
+</p>
+<p>
+  Two decisions are yours, and they are independent:
+</p>
+<ol>
+  <li>
+    <strong>What overrides to apply</strong> — declare the custom-property
+    overrides under a selector of your choosing. The documented convention is
+    <code>body.dark</code>, but any selector works (e.g. <code>[data-theme="dark"]</code>,
+    <code>.theme-dark</code>). The class itself does <em>nothing</em> without
+    these overrides; there is no default dark palette to fall back to.
+  </li>
+  <li>
+    <strong>When to apply it</strong> — decide how the selector gets added:
+    a <code>prefers-color-scheme</code> media query, a JavaScript toggle, a
+    stored user preference, or a manual <code>body.dark</code> class. Chota
+    does not add the class for you and does not ship a JS toggle.
+  </li>
+</ol>
+<p>
+  The custom properties below are the public API surface you can override —
+  the same tokens Chota's components consume. Override only the ones you want
+  to change; the rest keep their light-theme defaults.
+</p>
+{% highlight css %}
+/* 1. YOUR overrides — this is the only thing that makes "dark mode" dark. */
+/*    Chota ships no body.dark rule; this block is yours. */
+body.dark {
+  --bg-color: #000;
+  --bg-secondary-color: #131316;
+  --font-color: #f5f5f5;
+  --color-grey: #ccc;
+  --color-darkGrey: #777;
+}
+{% endhighlight %}
 {% highlight html %}
-  <style>
+<!-- 2. YOUR decision: when the .dark class is present. Choose ONE approach: -->
+
+<!-- Option A — media query only (no JS). Put the overrides INSIDE the query: -->
+<style>
+  @media (prefers-color-scheme: dark) {
     body.dark {
       --bg-color: #000;
       --bg-secondary-color: #131316;
@@ -127,14 +172,24 @@
       --color-grey: #ccc;
       --color-darkGrey: #777;
     }
-  </style>
-  <script>
-    if (window.matchMedia &&
-        window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      document.body.classList.add('dark');
-    }
-  </script>
+  }
+</style>
+
+<!-- Option B — JS adds the class; overrides live in a plain body.dark block. -->
+<script>
+  if (window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    document.body.classList.add('dark');
+  }
+</script>
 {% endhighlight %}
+<p>
+  A complete, runnable side-by-side example is in
+  <a href="./examples/dark-mode.html"><code>docs/examples/dark-mode.html</code></a>.
+  It uses only the documented custom properties above and renders light and
+  dark states from a deterministic switch so you can see both without relying
+  on the OS preference.
+</p>
     </section>
     <section id="components">
       <div class="row">


### PR DESCRIPTION
## Card #140 — document dark-mode customization convention

**Outcome:** documentation (no production CSS, JS, or test changes)

### Problem
The `Customizing` section of `docs/index.html` showed a `body.dark` example that implied adding the `.dark` class alone activates dark mode. It does **not**. Chota ships no `body.dark` rule and no default dark palette. `body.dark` is a **consumer convention** — a selector the consumer owns, where they override Chota's custom properties. The consumer must supply the overrides **and** decide when to add the class (media query, JS toggle, stored preference).

### Changes
- **`docs/index.html`** — Replaced the misleading `body.dark` example in the `Customizing` section with a corrected subsection that:
  - Explicitly states `body.dark` is a **convention**, not a Chota style block (Chota defines no `body.dark` rule).
  - Separates **"what overrides to apply"** from **"when to apply them"** as two independent consumer decisions.
  - Notes the class does nothing without the overrides (no default dark palette to fall back to).
  - Notes consumers may choose their own selector (`[data-theme=\"dark\"]`, `.theme-dark`, etc.); `body.dark` is the documented convention.
  - Shows a media-query-only option (Option A) and a JS-class-add option (Option B) as alternatives.
  - Links to the new runnable example.
- **`docs/examples/dark-mode.html`** (new) — Minimal, runnable side-by-side example:
  - Light and dark panes with identical markup; only the `.dark` class on the dark pane root differs.
  - Deterministic checkbox switch (no reliance on OS `prefers-color-scheme`).
  - Uses only documented custom properties (`--bg-color`, `--bg-secondary-color`, `--font-color`, `--color-grey`, `--color-darkGrey`).
  - Top comment explains the side-by-side mirror (`body.dark` is the documented convention; the demo uses a scoped `.demo-pane.dark` mirror so both states coexist on one page, since a page has only one `<body>`).

### Done checklist
- [x] Docs explicitly call `body.dark` a convention, not a library style block.
- [x] The example makes clear consumers supply overrides.
- [x] All documented tokens exist in built CSS and the API contract (`test/vrt/api-manifest.json`).
- [x] No default dark CSS or runtime behavior was introduced.

### Verification
```
yarn build → exit 0 (size gate 3372/3372 PASS)
grep -rn 'body.dark' src/*.css → NONE (consumer convention confirmed)
grep 'body.dark' dist/chota.css dist/chota.min.css → NONE
Custom props in example ⊆ test/vrt/api-manifest.json (14-token API): YES
test/vrt/dark-mode.spec.js contract unchanged: fixture inline <style> supplies
  the body.dark overrides; .card/.tag consume --bg-color/--color-grey.
```

### Scope
- Base: `v1` @ `78fbcf4`
- Files: `docs/index.html` (M), `docs/examples/dark-mode.html` (A)
- No production CSS, JS, test, snapshot, baseline, or config changes.
- `README.md` and `MIGRATION.md` reviewed — no contradictions (`MIGRATION.md` line 25 already lists `body.dark` as a preserved non-breaking contract; `README.md` does not mention dark mode).

### Out of scope / not done
- Did NOT merge this PR (coordinator handles merge).
- Did NOT update the project board or any GitHub issue.
- Did NOT touch `PLAN.md`, `AGENTS.md`, or any excluded file.

### Disposition
**promote** — documentation complete; ready for coordinator review and merge into `v1`.