### PR TITLE
Replace test:vrt spec list with discovery mechanism (#190)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "postcss": "postcss ./src/chota.css -d dist/",
     "watch": "cross-env NODE_ENV=development postcss ./src/chota.css -d dist/ -w",
     "test": "stylelint src/*.css",
-    "test:vrt": "npx playwright test test/vrt/index.spec.js test/vrt/components.spec.js test/vrt/grouped-controls.spec.js test/vrt/validations/mobile-grid-overflow.spec.js test/vrt/validations/nav-logo-full-height.spec.js test/vrt/validations/spacing-utilities.spec.js test/vrt/dark-mode.spec.js test/vrt/breakpoints.spec.js test/vrt/keyboard-focus.spec.js test/vrt/token-overrides.spec.js --project=chromium",
-    "test:a11y": "npx playwright test test/vrt/a11y.spec.js --project=chromium",
-    "test:api": "npx playwright test test/vrt/api.spec.js --project=chromium",
+    "test:vrt": "npx playwright test --project=chromium",
+    "test:a11y": "npx playwright test test/vrt/a11y.spec.js --project=chromium-a11y-api",
+    "test:api": "npx playwright test test/vrt/api.spec.js --project=chromium-a11y-api",
     "baselines": "node scripts/baselines.js"
   },
   "keywords": [

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -6,6 +6,19 @@ const BASE_CONTEXT_OPTIONS = {
   reducedMotion: 'reduce',
 };
 
+// Specs under test/vrt/ that are NOT part of the `test:vrt` gate. Each has its
+// own dedicated gate (test:a11y, test:api, browser smoke) or is manual-run
+// (root-font-scaling). They are excluded from the `chromium` project only, so
+// the `chromium-a11y-api` / `firefox` / `webkit` projects can still run them
+// by explicit path. New VRT specs need no edit here — they are picked up by
+// `chromium` discovery automatically.
+const NON_VRT_SPECS = [
+  '**/a11y.spec.js',
+  '**/api.spec.js',
+  '**/browser-smoke.spec.js',
+  '**/root-font-scaling.spec.js',
+];
+
 module.exports = defineConfig({
   testDir: './test/vrt',
   testMatch: '**/*.spec.js',
@@ -17,7 +30,19 @@ module.exports = defineConfig({
   },
   projects: [
     {
+      // The `test:vrt` gate: every spec under test/vrt/ except the non-VRT
+      // specs above. The project name MUST stay `chromium`: Playwright embeds
+      // the project name in the snapshot suffix, so renaming it would break
+      // every `-chromium-<platform>.png` baseline.
       name: 'chromium',
+      testIgnore: NON_VRT_SPECS,
+      use: { ...BASE_CONTEXT_OPTIONS, browserName: 'chromium', bypassCSP: true },
+    },
+    {
+      // Plain Chromium project for the dedicated a11y/api gates (explicit
+      // paths). No testIgnore, so it can run any spec by path. Produces no
+      // snapshots, so its name does not affect any baseline.
+      name: 'chromium-a11y-api',
       use: { ...BASE_CONTEXT_OPTIONS, browserName: 'chromium', bypassCSP: true },
     },
     {

--- a/test/vrt/README.md
+++ b/test/vrt/README.md
@@ -23,6 +23,29 @@ yarn test:api
 npx playwright test test/vrt/browser-smoke.spec.js --project=firefox --project=webkit
 ```
 
+## How the VRT gate is wired (#190)
+
+`test:vrt` no longer lists spec files. It runs `npx playwright test --project=chromium`, and Playwright discovers every `*.spec.js` under `test/vrt/` (via `testDir` + `testMatch` in `playwright.config.js`).
+
+The `chromium` project carries a per-project `testIgnore` that excludes the four specs which are **not** part of the VRT gate:
+
+| Excluded spec | Own gate |
+|---|---|
+| `a11y.spec.js` | `yarn test:a11y` (Chromium) |
+| `api.spec.js` | `yarn test:api` (Chromium) |
+| `browser-smoke.spec.js` | CI smoke step (Firefox + WebKit) |
+| `root-font-scaling.spec.js` | manual-run |
+
+Why per-project `testIgnore` instead of a top-level one: Playwright applies `testIgnore` even to files passed explicitly on the command line, so a top-level ignore would silently zero-out `test:a11y`, `test:api`, and the smoke step. The ignore therefore lives only on the `chromium` project; `test:a11y` / `test:api` run on the dedicated `chromium-a11y-api` project (no `testIgnore`, explicit paths) and the smoke step runs on `firefox` / `webkit`. The VRT project keeps the name `chromium` because Playwright embeds the project name in the snapshot suffix — renaming it would break every `-chromium-<platform>.png` baseline. All four gates stay Chromium-pinned (or Firefox/WebKit-only for smoke) and the CI gate order is unchanged.
+
+### Adding a VRT spec
+
+1. Drop a new `*.spec.js` under `test/vrt/` (validation specs go in `test/vrt/validations/`).
+2. That's it — no `package.json` or `playwright.config.js` edit. The spec is picked up by `chromium` discovery automatically and runs in `yarn test:vrt`.
+3. If the new spec produces screenshots, add the matching `-chromium-linux.png` (and `-chromium-darwin.png` for local runs) baselines under `test/vrt/snapshots/` — see [Snapshot Layout and Platform Policy](#snapshot-layout-and-platform-policy).
+
+Adding a non-VRT spec (e.g. a new a11y or API contract file) is the exception: add it to the `NON_VRT_SPECS` array in `playwright.config.js` and give it its own dedicated gate, mirroring `a11y.spec.js` / `api.spec.js`.
+
 ## Test Structure
 
 ```
@@ -136,6 +159,8 @@ To update Chromium baselines (e.g., after approved CSS changes):
 ```bash
 npx playwright test --project=chromium --update-snapshots
 ```
+
+(`--project=chromium` targets the VRT gate only — the `chromium` project's `testIgnore` keeps the non-VRT specs out, so this updates VRT baselines without running `test:a11y` / `test:api` / smoke / manual specs.)
 
 **Important**: Only update snapshots after owner review of the visual changes. The CI workflow uploads diff artifacts on failure for review.
 


### PR DESCRIPTION
## Summary

`test:vrt` in `package.json` no longer lists individual spec paths. It now runs `npx playwright test --project=chromium`, and Playwright discovers every `*.spec.js` under `test/vrt/` automatically. New VRT specs need **zero** `package.json` / `playwright.config.js` edits.

## Mechanism decision + rationale

**Per-project `testIgnore` on the `chromium` project**, with a new `chromium-a11y-api` project for the a11y/api gates.

Why not a top-level `testIgnore`: verified empirically that Playwright applies `testIgnore` even to files passed explicitly on the command line, so a global ignore silently zeroes out `test:a11y`, `test:api`, and the smoke step (experiment: explicit ignored path → 0 tests). The ignore therefore lives only on the `chromium` project.

Why the VRT project stays named `chromium`: Playwright embeds the **project name** in the snapshot suffix. An initial `chromium-vrt` rename made every screenshot resolve to `-chromium-vrt-darwin.png` and fail (30 baselines). Keeping the name `chromium` preserves all `-chromium-<platform>.png` baselines.

Result:
- `test:vrt` → `npx playwright test --project=chromium` (discovery)
- `chromium` project carries `testIgnore: NON_VRT_SPECS` (`a11y`, `api`, `browser-smoke`, `root-font-scaling`)
- `test:a11y` / `test:api` → `--project=chromium-a11y-api` (no `testIgnore`, explicit paths, no snapshots → zero baseline impact)
- `firefox` / `webkit` unchanged → smoke step stays Firefox/WebKit-only
- CI gate order and semantics unchanged (`ci.yml` untouched; CI invokes the yarn scripts)

## Changed files

- `package.json` — `test:vrt` (explicit 10-file list → `--project=chromium`); `test:a11y` / `test:api` (→ `--project=chromium-a11y-api`)
- `playwright.config.js` — `NON_VRT_SPECS` array + per-project `testIgnore` + `chromium-a11y-api` project
- `test/vrt/README.md` — "How the VRT gate is wired (#190)" + "Adding a VRT spec" + snapshot-update note

No spec files, assertions, fixtures, or baselines changed. No `ci.yml` change.

## Evidence

Environment: base SHA `0856b74`, branch `vitrine/replace-test-vrt-spec-list-with-discover-2f753e2f`, macOS (Darwin), Node v24.18.0, Yarn 1.22.22, commit `7091f9d`.

### Before/after `--list` diff per gate (primary proof)

| Gate | Before | After | Diff |
|---|---|---|---|
| `test:vrt` | 10 explicit files, 101 tests | `--project=chromium`, 101 tests | identical (same file/line/title; project prefix also unchanged `[chromium]`) |
| `test:a11y` | `--project=chromium`, 4 tests | `--project=chromium-a11y-api`, 4 tests | identical (only project-name prefix changed) |
| `test:api` | `--project=chromium`, 5 tests | `--project=chromium-a11y-api`, 5 tests | identical (only project-name prefix changed) |
| smoke | Firefox+WebKit, 8 tests | unchanged | identical |

Prefix-normalized diffs are empty for every gate. `a11y`/`api`/`browser-smoke`/`root-font-scaling` are confirmed absent from the `test:vrt` list output.

### Local gate exit statuses

- `yarn test:vrt` → **exit 0** (101 passed)
- `yarn test:a11y` → **exit 0** (4 passed)
- `yarn test:api` → **exit 0** (5 passed)
- smoke (`browser-smoke.spec.js`, Firefox+WebKit, `--workers 1`) → **exit 0** (8 passed)

### Snapshot baseline integrity

No spec file moved and the VRT project name is unchanged, so no snapshot baseline path changed (all `-chromium-darwin.png` / `-chromium-linux.png` baselines resolve as before). 30 stale `-chromium-vrt-*` artifacts from the aborted rename experiment were deleted (all untracked; no tracked counterpart).

## CI status

Not yet available — local results are local evidence only. CI check result will be reported when the GitHub Actions run completes.

## Done checklist

- [x] `test:vrt` no longer lists individual spec paths
- [x] New VRT spec needs zero edits to `package.json` / `playwright.config.js`
- [x] Before/after `--list` diff proves the same specs run in each gate
- [x] `test:vrt` / `test:a11y` / `test:api` Chromium-pinned; `browser-smoke` Firefox/WebKit-only; `root-font-scaling` manual-run
- [x] CI gate order unchanged
- [x] `test/vrt/README.md` documents the mechanism + "how to add a VRT spec"

## Out of scope

No new/renamed spec files, no changed assertions/fixtures/baselines, no new test runner, no Chromium-pinning change, no production CSS change.