### PR TITLE
docs(#142): write v1 migration guide, CHANGELOG, and public API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Chota Changelog
+
+This file documents released and unreleased changes to [Chota](https://github.com/jenil/chota).
+The `Unreleased` section tracks work merged to the `v1` integration branch that
+has not yet shipped to `main` or been published to npm.
+
+## Unreleased
+
+Work merged to the `v1` branch in preparation for the 1.0.0 release. Nothing
+here is published yet; the 1.0.0 release happens in card [#145](https://github.com/jenil/chota/issues/145).
+The full upgrade guide lives in [MIGRATION.md](./MIGRATION.md).
+
+### Breaking changes
+
+- **Internet Explorer 11 is no longer supported.** The `browserslist` policy is
+  now `last 2 Chrome versions`, `last 2 Firefox versions`, `last 2 Edge
+  versions`, `Safari >= 15.4`, `ios >= 15.4`. IE11 users see a degraded
+  experience; there is no legacy build. ([#122](https://github.com/jenil/chota/issues/122))
+- **Root font-size override removed.** Chota no longer sets
+  `html { font-size: 62.5% }`. The root font-size is the consumer's
+  responsibility and defaults to the browser's 16px. Every Chota-owned `rem`
+  value was divided by 1.6 so rendered pixels are unchanged at a 16px root.
+  Consumers who set `html { font-size: 62.5% }` themselves now see Chota render
+  at 0.625× its 16px-root size — proportional scaling, not a second baseline.
+  ([#137](https://github.com/jenil/chota/issues/137))
+
+### New features
+
+- **Visible keyboard focus.** A global `:focus-visible` rule applies
+  `outline: 2px solid var(--color-primary); outline-offset: 2px` to `a`,
+  `button`, `input`, `select`, `textarea`, `summary`, and `[tabindex]`. Form
+  controls retain their existing border + box-shadow focus signal, now scoped
+  to keyboard focus only (not mouse click). `:focus-visible` is supported
+  across the entire declared browserslist, so no `:focus` fallback is needed.
+  ([#139](https://github.com/jenil/chota/issues/139))
+- **Three new design tokens.** `--color-placeholder`, `--border-radius`, and
+  `--transition-duration` are now CSS custom properties on `:root`, replacing
+  previously hardcoded values. Defaults preserve the previous rendered output;
+  override on `:root` (or any selector) to theme all affected components at
+  once. ([#138](https://github.com/jenil/chota/issues/138))
+- **Grouped controls wrap on narrow viewports.** `.grouped` now applies
+  `flex-wrap: wrap` inside `@media (max-width: 480px)` so items wrap to a
+  vertical layout instead of overflowing horizontally. `.grouped.gapless`
+  keeps `gap: 0` to preserve joined borders. Desktop layout is unchanged.
+  ([#114](https://github.com/jenil/chota/issues/114), validated in
+  [#135](https://github.com/jenil/chota/issues/135), shipped via
+  [PR #170](https://github.com/jenil/chota/pull/170))
+
+### Documentation
+
+- `body.dark` is documented as a **consumer convention**, not a built-in theme.
+  Chota ships no `body.dark` rule and no default dark palette; the consumer
+  owns the selector, the overrides, and the decision of when to apply the
+  class. See the "Customizing" section of the docs site and
+  [`docs/examples/dark-mode.html`](./docs/examples/dark-mode.html).
+  ([#140](https://github.com/jenil/chota/issues/140))
+- **CSS-only interaction boundary** documented for `.dropdown` and `.tabs`:
+  Chota provides visual styling only. Native `<details>`/`<summary>` supplies
+  disclosure behavior; `.tabs` is visual navigation, not an ARIA Tabs widget.
+  Chota does not manage ARIA state, focus traps, or menu keyboard interaction.
+  ([#141](https://github.com/jenil/chota/issues/141))
+
+### Validation outcomes (no shipped change)
+
+The following reports were investigated and closed without a v1 code change.
+They are listed here so consumers can find the disposition; they are **not**
+shipped changes and are not part of the upgrade guide.
+
+- [#77](https://github.com/jenil/chota/issues/77) / [#133](https://github.com/jenil/chota/issues/133) — WordPress `body.tag` collision with `.tag`. Closed out-of-scope: the `.tag` public API is preserved; a future version may consider a prefixed build. See "Known limitations" in [MIGRATION.md](./MIGRATION.md).
+- [#102](https://github.com/jenil/chota/issues/102) / [#132](https://github.com/jenil/chota/issues/132) — mobile grid overflow. Validated; no v1 fix shipped.
+- [#111](https://github.com/jenil/chota/issues/111) / [#134](https://github.com/jenil/chota/issues/134) — full-height nav logo. Validated; no v1 fix shipped.
+- [#61](https://github.com/jenil/chota/issues/61) / [#136](https://github.com/jenil/chota/issues/136) — spacing utilities. Validated; no v1 fix shipped.
+
+### Tooling and quality
+
+- Standardized Yarn toolchain, portable size gate (4096-byte gzip ceiling),
+  architecture/workflow docs, dependency maintenance policy.
+  ([#123](https://github.com/jenil/chota/issues/123),
+  [#126](https://github.com/jenil/chota/issues/126),
+  [#127](https://github.com/jenil/chota/issues/127),
+  [#128](https://github.com/jenil/chota/issues/128))
+- CI quality gate, Chromium VRT, axe-core a11y baseline, CSS public API
+  contract, Firefox/WebKit smoke coverage.
+  ([#129](https://github.com/jenil/chota/issues/129),
+  [#124](https://github.com/jenil/chota/issues/124),
+  [#130](https://github.com/jenil/chota/issues/130),
+  [#131](https://github.com/jenil/chota/issues/131))
+- `test:vrt` discovery mechanism: new VRT specs need zero harness edits.
+  ([#190](https://github.com/jenil/chota/issues/190))

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,7 +12,7 @@ Chota 1.0.0 drops Internet Explorer 11 support. The `browserslist` policy was up
   "last 2 Firefox versions",
   "last 2 Edge versions",
   "Safari >= 15.4",
-  "iOS Safari >= 15.4"
+  "ios >= 15.4"
 ]
 ```
 
@@ -25,6 +25,107 @@ Chota 1.0.0 drops Internet Explorer 11 support. The `browserslist` policy was up
 - All public CSS class names remain compatible: `.container`, `.row`, `.col-*`, `.tag`, `body.dark`.
 - No changes to utility classes or component markup.
 - `!important` usage in utilities is preserved.
+
+## Visible Keyboard Focus
+
+### What changed
+
+Chota now applies a visible keyboard focus ring to all interactive elements via
+a global `:focus-visible` rule:
+
+```css
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+```
+
+Form controls (`input`, `select`, `textarea`) retain their existing border +
+box-shadow focus signal, but the selector switched from `:focus` to
+`:focus-visible` so the signal fires only on keyboard focus, not on mouse
+click. The previous `:focus` rule set `outline: none` and relied on the
+box-shadow alone; the new rule keeps the box-shadow and adds a real outline
+for elements that had no focus indicator before (links, buttons, summaries,
+tabindex elements).
+
+`:focus-visible` is supported across the entire declared browserslist
+(Safari 15.4+, iOS 15.4+, latest Chrome/Firefox/Edge), so no `:focus`
+fallback is needed.
+
+### Why
+
+The previous behavior hid the outline on form controls and showed nothing on
+links/buttons, which failed keyboard accessibility. The new rule gives every
+interactive element a visible focus ring on keyboard navigation without
+cluttering mouse-click interactions.
+
+### Consumer impact
+
+- **Consumers who rely on the browser default outline:** no action needed.
+  Chota now provides a consistent focus ring across all interactive elements.
+- **Consumers who set their own `:focus` / `:focus-visible` styles:**
+  override after importing `chota.css`. Chota's rule has the same specificity
+  as a single pseudo-class selector, so a same-or-higher-specificity rule on
+  the same elements wins.
+- **Consumers who previously set `outline: none` globally to hide the
+  browser default:** Chota's `:focus-visible` rule will re-introduce a focus
+  ring. If you want to suppress it, override `:focus-visible` explicitly.
+
+## Grouped Controls Wrap on Narrow Viewports
+
+### What changed
+
+`.grouped` now wraps its children to a vertical layout on narrow viewports
+instead of overflowing horizontally:
+
+```css
+.grouped {
+  display: flex;
+  gap: 0 16px;
+}
+
+@media (max-width: 480px) {
+  .grouped {
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  /* Gapless groups keep joined borders — no gap spacing. */
+  .grouped.gapless {
+    gap: 0;
+  }
+}
+```
+
+On desktop (viewports wider than 480px), `.grouped` stays horizontal — the
+existing behavior is unchanged. `.grouped.gapless` keeps `gap: 0` at every
+viewport so its joined-border geometry is preserved.
+
+### Why
+
+Previously `.grouped` used `margin-right: 16px` on children with no
+`flex-wrap`, so a group wider than its container overflowed horizontally on
+mobile. The fix adds `flex-wrap: wrap` scoped to narrow viewports and
+replaces the child margin with `gap`.
+
+### Consumer impact
+
+- **Consumers who relied on `.grouped` overflowing horizontally on mobile:**
+  it now wraps. This is the intended fix; if you need the old horizontal
+  overflow, override `flex-wrap: nowrap` on `.grouped` at your narrow
+  breakpoint.
+- **Consumers who set custom margins on `.grouped > *`:** the new `gap`
+  property replaces the old `margin-right: 16px` on non-last children. Custom
+  margins still apply; `gap` adds space between flex items on top of any
+  per-item margins.
+- **`.grouped.gapless` consumers:** no visual change. Joined borders and
+  zero spacing are preserved at every viewport.
 
 ## Root Font-Size Migration
 
@@ -86,3 +187,71 @@ Consumers previously had to override these values with specificity battles again
 ### Note on `.grouped.gapless`
 
 The `.grouped.gapless` first/last child rules use `var(--border-radius)` for their outer corners (preserving `!important`); the inner corners stay `0` because they are joined-border geometry, not a theming knob. Overriding `--border-radius` to `0` squares both standalone buttons and gapless group outer corners consistently.
+
+## `body.dark` Convention
+
+Chota ships **no** `body.dark` rule and **no** default dark palette. `body.dark`
+is a consumer convention: a selector the consumer owns, where they override
+Chota's custom properties. The consumer supplies both the overrides (which
+colors to apply) and the decision of when to apply the class (media query, JS
+toggle, stored preference).
+
+A runnable side-by-side example lives at
+[`docs/examples/dark-mode.html`](./docs/examples/dark-mode.html), and the
+"Customizing" section of the docs site documents the convention in full.
+
+## CSS-Only Interaction Boundary
+
+Chota is CSS-only. It provides visual styling for `.dropdown` and `.tabs` but
+does **not** manage behavior:
+
+- `.dropdown` is purely visual (`position: relative` + absolute last child).
+  Native `<details>`/`<summary>` supplies the disclosure behavior (Tab focus,
+  Enter/Space toggle) — that is browser-native, not Chota-provided.
+- `.tabs` is visual navigation links, not an ARIA Tabs widget.
+
+Chota does not manage ARIA state, focus traps, menu keyboard interaction, or
+tab-panel semantics. Consumers building interactive widgets layer their own
+JS and ARIA on top of Chota's visual styles.
+
+## Known Limitations
+
+These are documented limitations of v1, not shipped changes. They are listed
+here so consumers can find them before upgrading.
+
+- **WordPress `body.tag` collision with `.tag`.** WordPress adds a `tag`
+  class to the page `<body>` on tag archive pages, which collides with
+  Chota's `.tag` component selector and can apply Chota's tag styles to the
+  whole page. This is a real collision but renaming `.tag` would break
+  existing consumers, so v1 preserves the `.tag` public API. A future
+  version may consider a prefixed or separately built variant. See
+  [#133](https://github.com/jenil/chota/issues/133) for the full
+  disposition.
+
+## Unchanged Behavior
+
+The following are explicitly **not** changed in v1 and require no migration
+action:
+
+- `.container`, `.row`, `.col-*`, `.tag`, and `body.dark` public contracts.
+- Utility classes and component markup.
+- `!important` usage in utilities.
+- Em-based typography (`h1`–`h6`, `.tag.is-small`/`.is-large`, `.nav .brand`,
+  `code`/`kbd`) — always relative to the body font-size, which remains 16px.
+- The 12-column flexbox grid semantics.
+
+## Deferred or Closed Reports
+
+The following community reports were investigated during v1 development and
+closed without a shipped fix. They are listed here so consumers searching the
+issue tracker can find the disposition. None of these appear in the shipped
+change list above.
+
+- [#77](https://github.com/jenil/chota/issues/77) — WordPress `body.tag`
+  collision. Closed out-of-scope; see Known Limitations above.
+- [#102](https://github.com/jenil/chota/issues/102) — mobile grid overflow.
+  Validated under the v1 support matrix; no v1 fix shipped.
+- [#111](https://github.com/jenil/chota/issues/111) — full-height nav logo.
+  Validated; the existing opt-in behavior works as documented.
+- [#61](https://github.com/jenil/chota/issues/61) — spacing utilities.
+  Validated; utilities deliver their documented semantics.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,21 @@ yarn add chota
 #### SASS support
 Chota is designed keeping in mind *ease-of-use* and *minimalism*, hence it doesn't use any preprocessor or complex build process. If you would still like to extend it further using SASS, head to [palmiak's fork](https://github.com/palmiak/chota).
 
+#### Upgrading from 0.9.x
+See [MIGRATION.md](./MIGRATION.md) for the v1 upgrade guide, including the
+root font-size migration, new design tokens, visible keyboard focus, and
+browser support changes.
+
 <br>
 
 ## Browsers support
 
-| [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="IE / Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>IE / Edge | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>iOS Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/samsung-internet/samsung-internet_48x48.png" alt="Samsung" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Samsung | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png" alt="Opera" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Opera |
-| --------- | --------- | --------- | --------- | --------- | --------- | --------- |
-| IE11, Edge| last 2 versions| last 2 versions| last 2 versions| last 2 versions| last 2 versions| last 2 versions
+| [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Edge | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)<br/>iOS Safari |
+| --------- | --------- | --------- | --------- | --------- |
+| last 2 versions | last 2 versions | last 2 versions | 15.4+ | 15.4+ |
+
+Internet Explorer 11 and Opera are no longer supported in v1. See
+[MIGRATION.md](./MIGRATION.md) for the full support policy and upgrade guide.
 
 ## Contributing
 Welcome! Please see our [contributing guidelines](https://github.com/jenil/chota/blob/master/.github/CONTRIBUTING.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,10 +85,30 @@ Chota exposes CSS custom properties for theming. Override on `:root` or any sele
 
 Common helper classes: `.is-hidden`, `.is-marginless`, `.is-paddingless`, text alignment, etc.
 
+### `body.dark` Convention
+
+Chota ships **no** `body.dark` rule and **no** default dark palette.
+`body.dark` is a consumer convention: the consumer owns the selector, the
+custom-property overrides, and the decision of when to apply the class. See
+[`docs/examples/dark-mode.html`](./examples/dark-mode.html) for a runnable
+example.
+
+### CSS-Only Interaction Boundary
+
+Chota is CSS-only. `.dropdown` is purely visual — native `<details>`/`<summary>`
+supplies disclosure behavior. `.tabs` is visual navigation, not an ARIA Tabs
+widget. Chota does not manage ARIA state, focus traps, or menu/tab keyboard
+interaction; consumers layer their own JS and ARIA on top.
+
 ## Release Flow
 
 1. **Build**: `yarn build` — lint, process CSS, minify, report size
-2. **Verify**: Check `dist/` output, size under 4KB gzip ceiling
+2. **Verify**: Check `dist/` output, size under the 4096-byte gzip ceiling
+   (current baseline: 3409 bytes)
 3. **Publish**: `npm publish` — publishes `chota@1.0.0` to npm
 
-The repository publishes a single package: `chota`. The `main` field in `package.json` points to `dist/chota.min.css`.
+The repository publishes a single package: `chota`. The `main` field in
+`package.json` points to `dist/chota.min.css`.
+
+See [MIGRATION.md](../MIGRATION.md) for the v1 upgrade guide and
+[CHANGELOG.md](../CHANGELOG.md) for the change history.


### PR DESCRIPTION
## Card

Closes #142 — v1: write migration guide and public API reference.

## Outcome

Documentation. No production CSS, no public API change, no test-harness change. Source-accurate v1 migration documentation covering every shipped public-behavior change in Week 3.

## Changed files

| File | Change |
|---|---|
| `CHANGELOG.md` | NEW — `Unreleased` section: breaking changes (#122, #137), new features (#139, #138, #114), documentation (#140, #141), validation outcomes (#77/#133, #102/#132, #111/#134, #61/#136 — all marked "no shipped change"), tooling (#123–#131, #190) |
| `MIGRATION.md` | +171 lines: #139 visible-keyboard-focus section (exact `:focus-visible` rule + before/after), #114 grouped-controls-wrap section (media-query rule + consumer impact), `body.dark` convention pointer, CSS-only interaction boundary, Known Limitations (#77 WordPress collision), Deferred/Closed Reports, Unchanged Behavior. Browserslist JSON block uses valid `"ios >= 15.4"` query matching `package.json`. |
| `README.md` | Browsers support table updated to v1 policy (Edge/Firefox/Chrome last 2, Safari/iOS 15.4+, IE11 and Opera dropped); "Upgrading from 0.9.x" link added. |
| `docs/architecture.md` | `body.dark` Convention + CSS-Only Interaction Boundary sections; 4096-byte ceiling + 3409 baseline note; links to MIGRATION/CHANGELOG. |

## Change ledger (shipped public-behavior changes in v1)

| Card | Change | User impact | Migration action | Source proof |
|---|---|---|---|---|
| #122 | IE11 dropped; browserslist updated | IE11 users see degraded experience | Stay on 0.9.x if IE11 is required | `package.json` browserslist |
| #137 | Root `62.5%` override removed; rem divided by 1.6 | No visual change at 16px root; 0.625× scaling if consumer sets 62.5% | None unless consumer set `html { font-size: 62.5% }` | no `62.5%` in `src/_base.css` or `dist/chota.css` |
| #138 | 3 new tokens: `--color-placeholder`, `--border-radius`, `--transition-duration` | No visual change (defaults preserve output); override on `:root` to theme | None unless overriding | `src/_base.css:18-20` |
| #139 | Global `:focus-visible` rule; form controls switch `:focus`→`:focus-visible` | Visible keyboard focus ring on all interactive elements | None unless suppressing outline | `src/_form.css:84-93, 147-153` (12 focus-visible occurrences) |
| #114 | `.grouped` wraps at `max-width: 480px` | Narrow-viewport groups wrap instead of overflowing | Override `flex-wrap: nowrap` if old overflow needed | `src/_form.css:126-135` |

## Deferred/closed reports (NOT shipped, listed for discoverability)

- #77 / #133 — WordPress `body.tag` collision. Closed out-of-scope; `.tag` API preserved.
- #102 / #132 — mobile grid overflow. Validated; no v1 fix.
- #111 / #134 — full-height nav logo. Validated; no v1 fix.
- #61 / #136 — spacing utilities. Validated; no v1 fix.

Grep-verified: none of these appear in the shipped-change sections of MIGRATION.md or CHANGELOG.md.

## Validation (macOS, Node 24.18.0, Yarn 1.22.22, Chromium)

| Command | Exit | Result |
|---|---|---|
| `yarn build` | 0 | 3409 gzip bytes (unchanged from baseline, within 4096 ceiling) |
| `yarn test` (stylelint) | 0 | PASS |
| `yarn test:api` | 0 | 5 passed |
| `yarn test:vrt` | 0 | 101 passed |
| `yarn test:a11y` | 0 | 4 passed |
| `git diff --check` | 0 | No whitespace errors |

## Source-accuracy proof

- #137: no `62.5%` override in `src/_base.css` or `dist/chota.css`
- #138: 3 tokens at `src/_base.css:18-20`
- #139: 12 `focus-visible` occurrences in `src/_form.css`
- #114: `flex-wrap: wrap` at `src/_form.css:128`
- #122: `package.json` browserslist matches MIGRATION.md JSON block and CHANGELOG.md prose (both say `"ios >= 15.4"`, no invalid `"iOS Safari"` query)
- gzip 3409 in `docs/architecture.md` matches `baselines/size-baseline.json:11`
- All 17 `test/vrt/api-manifest.json` tokens present in `docs/architecture.md:60-65`
- README "iOS Safari" is the human-readable table column label (alt text), not a Browserslist query — correct as-is

## Front-end CSS expert review

Spawned a sub-agent with a front-end CSS expert system prompt to review all Week 3 work (#137, #138, #139, #140, #141, #190, #180, #114, #142). Result: **PASS 9, MINOR 2, MAJOR 1, BLOCKER 0**.

- All 8 completed Week 3 cards: PASS on both Standards and Spec axes.
- #142 working tree: one MAJOR (invalid `"iOS Safari >= 15.4"` Browserslist query in MIGRATION.md and CHANGELOG.md) — **fixed before commit** (changed to `"ios >= 15.4"` to match `package.json`).
- Two MINOR follow-ups filed for future cards (not blocking):
  1. #138 follow-up: stale "14 tokens" comment in `docs/examples/dark-mode.html:13` (should reflect 17-token API).
  2. Test-harness follow-up: `test/vrt/README.md:82` a11y row says "index.html" but spec runs on both index.html and components.html.

## Impact

- **API:** none (`api-manifest.json` untouched; version stays 0.9.2 — version bump is a Week 4 #143 action)
- **Source:** none (no `src/` edits)
- **Dist:** none (regenerated by build, byte-identical to baseline)
- **Size:** none (3409 bytes, within 4096 ceiling)
- **VRT:** none (101 passed, no fixture/baseline changes)
- **a11y:** none (4 passed, no fixture changes)

## Clean-checkout review (card requirement)

The card requires a reviewer to execute the documented commands from a fresh clone. The agent cannot self-review. Owner should run:

```sh
git clone <this PR branch>
cd chota
yarn install --frozen-lockfile
yarn build
yarn test
yarn test:api
yarn test:vrt
yarn test:a11y
```

Confirm each exit 0, then read MIGRATION.md and CHANGELOG.md for source/API mismatches.

## Unresolved risk

None from the agent. Two follow-up cards filed (see CSS-expert review above). Owner decisions pending: clean-checkout review result, and confirmation that a new CHANGELOG.md is the desired location/format (repo has never had one) vs. deferring to #145.

## Commit

`ff5bc0991483e738abf99f124d8a7e921b9f833a` on `work/142-migration-guide` → `v1`.